### PR TITLE
Convert image to RGB format in inference notebook

### DIFF
--- a/sample_inference.ipynb
+++ b/sample_inference.ipynb
@@ -82,7 +82,7 @@
     }
    ],
    "source": [
-    "img = Image.open(\"./datasets/slideredit_faces_dataset/woman_7.png\")\n",
+    "img = Image.open(\"./datasets/slideredit_faces_dataset/woman_7.png\").convert(\"RGB\")\n",
     "edit_prompt = \"make the hair of the person curly\"\n",
     "alpha_values = [1, 0.8, 0.5, 0, -0.5, -1]\n",
     "\n",


### PR DESCRIPTION
This allows the notebook to process RGBA images.